### PR TITLE
DO NOT MERGE & DO NOT DELETE - Dom ready check

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -230,7 +230,7 @@ Utils.matchMedia = function(doc) {
 // for the IE10 fix
 Utils.domIsReady = function(doc) {
     var doc = doc || document;
-    return doc.attachEvent ? doc.readyState === "complete" : doc.readyState !== "loading";
+    return doc.readyState === "complete";
 };
 
 Utils.getPhysicalScreenSize = function(devicePixelRatio) {


### PR DESCRIPTION
# DO NOT MERGE & DO NOT DELETE

We are suspecting Safari mobile not allowing to `document.open`, `document.write`, and `document.close` when `document.readyState =`interactive'`. We are relying on this check to start capturing document in Capturejs https://github.com/mobify/capturejs/pull/15
